### PR TITLE
Simpler FastAPI usage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,9 @@
 name: docs
 on:
-  push:
-    branches: [master]
+  release:
+    types:
+      - published
+      - edited
 
 jobs:
   deploy-docs:

--- a/docs/examples_src/usage_fastapi/base_example.py
+++ b/docs/examples_src/usage_fastapi/base_example.py
@@ -1,10 +1,8 @@
 from typing import List
 
-import uvicorn
 from fastapi import FastAPI, HTTPException
 
 from odmantic import AIOEngine, Model, ObjectId
-from odmantic.fastapi import AIOEngineDependency
 
 
 class Tree(Model):
@@ -15,34 +13,30 @@ class Tree(Model):
 
 app = FastAPI()
 
-EngineD = AIOEngineDependency()
+engine = AIOEngine()
 
 
 @app.put("/trees/", response_model=Tree)
-async def create_tree(tree: Tree, engine: AIOEngine = EngineD):
+async def create_tree(tree: Tree):
     await engine.save(tree)
     return tree
 
 
 @app.get("/trees/", response_model=List[Tree])
-async def get_trees(engine: AIOEngine = EngineD):
+async def get_trees():
     trees = await engine.find(Tree)
     return trees
 
 
 @app.get("/trees/count", response_model=int)
-async def count_trees(engine: AIOEngine = EngineD):
+async def count_trees():
     count = await engine.count(Tree)
     return count
 
 
 @app.get("/trees/{id}", response_model=Tree)
-async def get_tree_by_id(id: ObjectId, engine: AIOEngine = EngineD):
+async def get_tree_by_id(id: ObjectId):
     tree = await engine.find_one(Tree, Tree.id == id)
     if tree is None:
         raise HTTPException(404)
     return tree
-
-
-if __name__ == "__main__":
-    uvicorn.run(app, host="localhost", port=8080)

--- a/docs/examples_src/usage_fastapi/example_delete.py
+++ b/docs/examples_src/usage_fastapi/example_delete.py
@@ -2,7 +2,6 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 
 from odmantic import AIOEngine, Model, ObjectId
-from odmantic.fastapi import AIOEngineDependency
 
 
 class Tree(Model):
@@ -13,11 +12,11 @@ class Tree(Model):
 
 app = FastAPI()
 
-EngineD = AIOEngineDependency()
+engine = AIOEngine()
 
 
 @app.get("/trees/{id}", response_model=Tree)
-async def get_tree_by_id(id: ObjectId, engine: AIOEngine = EngineD):
+async def get_tree_by_id(id: ObjectId):
     tree = await engine.find_one(Tree, Tree.id == id)
     if tree is None:
         raise HTTPException(404)
@@ -25,13 +24,9 @@ async def get_tree_by_id(id: ObjectId, engine: AIOEngine = EngineD):
 
 
 @app.delete("/trees/{id}", response_model=Tree)
-async def delete_tree_by_id(id: ObjectId, engine: AIOEngine = EngineD):
+async def delete_tree_by_id(id: ObjectId):
     tree = await engine.find_one(Tree, Tree.id == id)
     if tree is None:
         raise HTTPException(404)
     await engine.delete(tree)
     return tree
-
-
-if __name__ == "__main__":
-    uvicorn.run(app, host="localhost", port=8080)

--- a/docs/examples_src/usage_fastapi/example_update.py
+++ b/docs/examples_src/usage_fastapi/example_update.py
@@ -5,7 +5,6 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from odmantic import AIOEngine, Model, ObjectId
-from odmantic.fastapi import AIOEngineDependency
 
 
 class Tree(Model):
@@ -16,11 +15,11 @@ class Tree(Model):
 
 app = FastAPI()
 
-EngineD = AIOEngineDependency()
+engine = AIOEngine()
 
 
 @app.get("/trees/{id}", response_model=Tree)
-async def get_tree_by_id(id: ObjectId, engine: AIOEngine = EngineD):
+async def get_tree_by_id(id: ObjectId):
     tree = await engine.find_one(Tree, Tree.id == id)
     if tree is None:
         raise HTTPException(404)
@@ -34,11 +33,7 @@ class TreePatchSchema(BaseModel):
 
 
 @app.patch("/trees/{id}", response_model=Tree)
-async def update_tree_by_id(
-    id: ObjectId,
-    patch: TreePatchSchema,
-    engine: AIOEngine = EngineD,
-):
+async def update_tree_by_id(id: ObjectId, patch: TreePatchSchema):
     tree = await engine.find_one(Tree, Tree.id == id)
     if tree is None:
         raise HTTPException(404)
@@ -48,7 +43,3 @@ async def update_tree_by_id(
         setattr(tree, name, value)
     await engine.save(tree)
     return tree
-
-
-if __name__ == "__main__":
-    uvicorn.run(app, host="localhost", port=8080)

--- a/odmantic/fastapi.py
+++ b/odmantic/fastapi.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 import fastapi.params
@@ -8,6 +9,11 @@ from odmantic.engine import AIOEngine
 
 class AIOEngineDependency(fastapi.params.Depends):
     """AIOEngine FastAPI Dependency.
+
+
+    Warning:
+        Deprecated since v0.2.0, [more
+        details](https://art049.github.io/odmantic/usage_fastapi/#building-the-engine).
 
     Internally caches the AIOEngine instance to avoid creating a new client on each
     request.
@@ -22,6 +28,7 @@ class AIOEngineDependency(fastapi.params.Depends):
         await engine.find(...)
         await engine.save(...)
     ```
+
     """
 
     def __init__(self, mongo_uri: Optional[str] = None, database: str = "test") -> None:
@@ -35,6 +42,12 @@ class AIOEngineDependency(fastapi.params.Depends):
         self.mongo_uri = mongo_uri
         self.database = database
         self.engine: Optional[AIOEngine] = None
+        warnings.warn(
+            "the AIOEngineDependency object is deprecated, see "
+            "https://art049.github.io/odmantic/usage_fastapi/#building-the-engine "
+            "for more details.",
+            DeprecationWarning,
+        )
 
     async def __call__(self) -> AIOEngine:
         if self.engine is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ skip = ["docs"]
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:\"@coroutine\" decorator is deprecated.*:DeprecationWarning:motor.*",
+    "ignore:the AIOEngineDependency object is deprecated.*:DeprecationWarning:odmantic.*",
 ]
 
 [tool.coverage.run]

--- a/tests/fastapi/test_dependency.py
+++ b/tests/fastapi/test_dependency.py
@@ -59,3 +59,10 @@ def test_fastapi_dependency_custom_uri(fastapi_app: FastAPI, test_client: TestCl
 
     response = test_client.get("/")
     assert response.status_code == 200
+
+
+def test_fastapi_dependency_deprecation_warning():
+    with pytest.warns(
+        DeprecationWarning, match="the AIOEngineDependency object is deprecated"
+    ):
+        AIOEngineDependency()


### PR DESCRIPTION
Deprecate `AIOEngineDependency` and recommend to use a global `engine` object to reduce the verbosity required to use the engine.