### PR TITLE
Update Filtering.md to include Bitwise Operator Warning

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -149,6 +149,10 @@ objects with logical operators:
 1. Using python 'bitwise' operators between the field of the model and the desired value
 :   `&`, `|`
 
+!!! warning
+    When using those operators make sure to correctly bracket the expressions
+    to avoid python operator precedence issues.
+
 2. Using the functions provided by the `odmantic.query` module
     - [query.and_][odmantic.query.and_]
     - [query.or_][odmantic.query.or_]


### PR DESCRIPTION
As per issue #23 

Added the Python Bitwise operator warning found in Documentation [API Reference > odmantic.query](https://art049.github.io/odmantic/api_reference/query/#odmantic.query.QueryExpression) to [Filtering > Logical Operators' section](https://art049.github.io/odmantic/filtering/#logical-operators) as well. 

This will be a useful reminder to those who forget to add parenthesis when using bitwise operator comparisons and may overlook the API Reference section which explains why it's necessary to do so..