### PR TITLE
Don't replace field description for ObjectId

### DIFF
--- a/odmantic/bson.py
+++ b/odmantic/bson.py
@@ -27,8 +27,7 @@ class ObjectId(bson.ObjectId):
     def __modify_schema__(cls, field_schema: Dict) -> None:
         field_schema.update(
             examples=["5f85f36d6dfecacc68428a46", "ffffffffffffffffffffffff"],
-            example="ffffffffffffffffffffffff",
-            description="MongoDB ObjectId string",
+            example="5f85f36d6dfecacc68428a46",
             type="string",
         )
 


### PR DESCRIPTION
Don't replace field description for ObjectId with `MongoDB ObjectId string`
Let developer to define own description for an ObjectId field :)

Fixes #79 

