### PR TITLE
`bypass validation` and other params become optional; fixed transactions; minor refactor

### DIFF
--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -300,7 +300,6 @@ class AIOEngine:
         self, instance: ModelType, session: AsyncIOMotorClientSession, **kwargs: Any
     ) -> ModelType:
         """Perform an atomic save operation in the specified session"""
-
         # recursive saving for embedded instances
         save_tasks = []
         for ref_field_name in instance.__references__:

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -297,7 +297,7 @@ class AIOEngine:
         return results[0]
 
     async def _save(
-        self, instance: ModelType, session: AsyncIOMotorClientSession, **kwargs
+        self, instance: ModelType, session: AsyncIOMotorClientSession, **kwargs: Any
     ) -> ModelType:
         """Perform an atomic save operation in the specified session"""
 
@@ -328,7 +328,7 @@ class AIOEngine:
             object.__setattr__(instance, "__fields_modified__", set())
         return instance
 
-    async def save(self, instance: ModelType, **kwargs) -> ModelType:
+    async def save(self, instance: ModelType, **kwargs: Any) -> ModelType:
         """Persist an instance to the database
 
         This method behaves as an 'upsert' operation. If a document already exists

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -337,10 +337,8 @@ class AIOEngine:
 
         Args:
             instance: instance to persist
-
-        Kwargs:
-            Pass kwarg to overwrite any `collection.update_one(...)` parameter.
-            By default `filter`, `update`, `upsert` and `session` already provided.
+            kwargs: pass kwarg to overwrite any `.update_one(...)` parameter. By
+                default `filter`, `update`, `upsert` and `session` already provided.
 
         Returns:
             the saved instance


### PR DESCRIPTION
## Fixed 
- [x] session was not passed to `collection.update_one()` method, so **all previous savings was outside the transaction**
- [x] `__fields_modified__` set was previously cleared only for the top-level instance, but now this happens for the entire tree of embedded instances.

## Updated
- [x] all `collection.update_one()` kwargs become optional. This way user may control `upsert`, `bypass_document_validation` and other options to change `.save()` method behaviour, as described in #69
- [x] removed reudant `list` to `set` convertion, checking of `set` lengh > 0, e.t.c.

## Added
- [x] some comments to make code reading clear for newbies :) 