### PR TITLE
Fix modified mark clearing on save for nested models

### DIFF
--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -318,6 +318,7 @@ class AIOEngine:
                 upsert=True,
                 bypass_document_validation=True,
             )
+            object.__setattr__(instance, "__fields_modified__", set())
         return instance
 
     async def save(self, instance: ModelType) -> ModelType:
@@ -348,7 +349,6 @@ class AIOEngine:
         async with await self.client.start_session() as s:
             async with s.start_transaction():
                 await self._save(instance, s)
-        object.__setattr__(instance, "__fields_modified__", set())
         return instance
 
     async def save_all(self, instances: Sequence[ModelType]) -> List[ModelType]:


### PR DESCRIPTION
`__fields_modified__` cleared also for embedded models on save

Fixes #87

