### PR TITLE
Allow models to contain string-based datetime fields that indicate UTC

### DIFF
--- a/odmantic/bson.py
+++ b/odmantic/bson.py
@@ -1,6 +1,6 @@
 import decimal
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, Pattern, cast
 
 import bson
@@ -142,7 +142,7 @@ class _datetime(datetime):
             d = parse_datetime(v)
         # MongoDB does not store timezone info
         # https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive
-        if d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None:
+        if d.tzinfo is not None and d.tzinfo.utcoffset(d) != timedelta(0):
             raise ValueError("datetime objects must be naive (no timezone info)")
         # Truncate microseconds to milliseconds to comply with Mongo behavior
         microsecs = d.microsecond - d.microsecond % 1000

--- a/tests/unit/test_bson_fields.py
+++ b/tests/unit/test_bson_fields.py
@@ -20,11 +20,18 @@ def test_datetime_non_naive():
     class ModelWithDate(Model):
         field: datetime
 
-    with pytest.raises(ValueError):
+    try:
         ModelWithDate(field=datetime.now(tz=pytz.utc))
+        ModelWithDate(field="2018-11-02T23:59:01.824Z")
+        ModelWithDate(field="2018-11-02T23:59:01.824+00:00")
+    except ValueError:
+        pytest.fail("UTC should be acceptable, but is not")
 
     with pytest.raises(ValueError):
         ModelWithDate(field=datetime.now(tz=pytz.timezone("Europe/Amsterdam")))
+
+    with pytest.raises(ValueError):
+        ModelWithDate(field="2018-11-02T23:59:01.824+10:00")
 
 
 def test_datetime_naive():

--- a/tests/unit/test_bson_fields.py
+++ b/tests/unit/test_bson_fields.py
@@ -20,18 +20,32 @@ def test_datetime_non_naive():
     class ModelWithDate(Model):
         field: datetime
 
-    try:
-        ModelWithDate(field=datetime.now(tz=pytz.utc))
-        ModelWithDate(field="2018-11-02T23:59:01.824Z")
-        ModelWithDate(field="2018-11-02T23:59:01.824+00:00")
-    except ValueError:
-        pytest.fail("UTC should be acceptable, but is not")
-
     with pytest.raises(ValueError):
         ModelWithDate(field=datetime.now(tz=pytz.timezone("Europe/Amsterdam")))
 
     with pytest.raises(ValueError):
         ModelWithDate(field="2018-11-02T23:59:01.824+10:00")
+
+
+def test_datetime_non_naive_utc():
+    class ModelWithDate(Model):
+        field: datetime = Field(datetime.now(tz=pytz.utc))
+
+    ModelWithDate()
+
+
+def test_datetime_non_naive_utc_as_simplified_extended_iso_format_string():
+    class ModelWithDate(Model):
+        field: datetime = Field("2018-11-02T23:59:01.824Z")
+
+    ModelWithDate()
+
+
+def test_datetime_non_naive_utc_as_gmt_zero_offset_string():
+    class ModelWithDate(Model):
+        field: datetime = Field("2018-11-02T23:59:01.824+00:00")
+
+    ModelWithDate()
 
 
 def test_datetime_naive():


### PR DESCRIPTION
Treats the following as valid datetime string values:

* `2018-11-02T23:59:01.824` (assumed to be UTC)
* `2018-11-02T23:59:01.824Z` (UTC in simplified extended ISO format)
* `2018-11-02T23:59:01.824+00:00` (GMT, equivalent to UTC)

Fixes #135.