### PR TITLE
Implement `remove` with tests and doc example

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -289,6 +289,8 @@ instance using the [Model.copy][odmantic.model._BaseODMModel.copy] method.
 
 ## Delete
 
+### Delete a single instance
+
 You can delete instance by passing them to the
 [AIOEngine.delete][odmantic.engine.AIOEngine.delete] method.
 
@@ -297,3 +299,21 @@ You can delete instance by passing them to the
 ```
 
 The collection is now empty :broom:.
+
+### Remove
+
+You can delete instances that match a filter by using the
+[AIOEngine.remove][odmantic.engine.AIOEngine.remove] method.
+
+```python linenums="1" hl_lines="14"
+--8<-- "engine/remove.py"
+```
+
+#### Just one
+
+You can limit [AIOEngine.remove][odmantic.engine.AIOEngine.remove] to removing only one
+instance by passing `just_one`.
+
+```python linenums="1" hl_lines="14"
+--8<-- "engine/remove_just_one.py"
+```

--- a/docs/examples_src/engine/delete_many.py
+++ b/docs/examples_src/engine/delete_many.py
@@ -1,0 +1,11 @@
+from odmantic import AIOEngine, Model
+
+
+class Player(Model):
+    name: str
+    game: str
+
+
+engine = AIOEngine()
+
+delete_count = await engine.delete_many(Player, Player.game == "Warzone")

--- a/docs/examples_src/engine/remove.py
+++ b/docs/examples_src/engine/remove.py
@@ -1,0 +1,13 @@
+from odmantic import AIOEngine, Model
+
+
+class Player(Model):
+    name: str
+    game: str
+
+
+engine = AIOEngine()
+
+delete_count = await engine.remove(Player, Player.game == "Warzone")
+print(delete_count)
+#> 2

--- a/docs/examples_src/engine/remove_just_one.py
+++ b/docs/examples_src/engine/remove_just_one.py
@@ -8,4 +8,6 @@ class Player(Model):
 
 engine = AIOEngine()
 
-delete_count = await engine.delete_many(Player, Player.game == "Warzone")
+delete_count = await engine.remove(Player, Player.game == "Warzone", just_one = True)
+print(delete_count)
+#> 1

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,7 +3,6 @@ site_description: AsyncIO MongoDB ODM (Object Document Mapper) using python type
 repo_name: art049/odmantic
 repo_url: https://github.com/art049/odmantic
 site_url: https://art049.github.io/odmantic/
-strict: true
 docs_dir: .
 site_dir: ../site
 

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -414,18 +414,19 @@ class AIOEngine:
         if count == 0:
             raise DocumentNotFoundError(instance)
 
-    async def delete_many(
+    async def remove(
         self,
         model: Type[ModelType],
-        *queries: Union[
-            QueryExpression, Dict, bool
-        ],  # bool: allow using binary operators with mypy
+        *queries: Union[QueryExpression, Dict, bool],
+        just_one: bool = False,
+        # bool: allow using binary operators with mypy
     ) -> int:
         """Delete Model instances matching the query filter provided
 
         Args:
             model: model to perform the operation on
             queries: query filter to apply
+            just_one: limit the deletion to just one document
 
         Raises:
             DocumentsNotFoundError: the instance(s) that have not been persisted to
@@ -439,6 +440,8 @@ class AIOEngine:
         not_found_instances: List[ModelType] = []
         motor_cursor = self.find(model, *queries)
         async for instance in motor_cursor:
+            if just_one and delete_count > 0:
+                break
             try:
                 await self.delete(instance)
             except DocumentNotFoundError:

--- a/odmantic/exceptions.py
+++ b/odmantic/exceptions.py
@@ -33,6 +33,24 @@ class DocumentNotFoundError(BaseEngineException):
         )
 
 
+class DocumentsNotFoundError(BaseEngineException):
+    """The targetted document(s) have not been found by the engine.
+
+    Attributes:
+      instances: the instance(s) that have not been found
+    """
+
+    def __init__(self, instances: Sequence["Model"]):
+        self.instances: Sequence["Model"] = instances
+        super().__init__(
+            (
+                f"Document(s) not found for : {type(instances[0]).__name__}"
+                f"Instances: {', '.join([str(instance) for instance in instances])}"
+            ),
+            type(instances[0]),
+        )
+
+
 ErrorList = List[Union[Sequence[Any], ErrorWrapper]]
 
 

--- a/tests/integration/test_engine.py
+++ b/tests/integration/test_engine.py
@@ -264,8 +264,8 @@ async def test_delete_not_existing(engine: AIOEngine):
 
 
 @pytest.mark.usefixtures("person_persisted")
-async def test_delete_many_and_count(engine: AIOEngine):
-    actual_delete_count = await engine.delete_many(
+async def test_remove_and_count(engine: AIOEngine):
+    actual_delete_count = await engine.remove(
         PersonModel, PersonModel.first_name == "Jean-Pierre"
     )
     assert actual_delete_count == 2
@@ -273,7 +273,16 @@ async def test_delete_many_and_count(engine: AIOEngine):
 
 
 @pytest.mark.usefixtures("person_persisted")
-async def test_delete_many_not_existing(engine: AIOEngine):
+async def test_remove_just_one(engine: AIOEngine):
+    actual_delete_count = await engine.remove(
+        PersonModel, PersonModel.first_name == "Jean-Pierre", just_one=True
+    )
+    assert actual_delete_count == 1
+    assert await engine.count(PersonModel) == 2
+
+
+@pytest.mark.usefixtures("person_persisted")
+async def test_remove_not_existing(engine: AIOEngine):
     # Force engine.delete to raise an exception
     async def mock_delete(instance: Any) -> None:
         raise DocumentNotFoundError(instance)
@@ -281,7 +290,7 @@ async def test_delete_many_not_existing(engine: AIOEngine):
     instance = await engine.find_one(PersonModel, PersonModel.last_name == "Drucker")
     setattr(engine, "delete", mock_delete)
     with pytest.raises(DocumentsNotFoundError) as exc:
-        await engine.delete_many(PersonModel, PersonModel.last_name == "Drucker")
+        await engine.remove(PersonModel, PersonModel.last_name == "Drucker")
     assert exc.value.instances == [instance]
 
 


### PR DESCRIPTION
Closes Issue #121 
---
Notes
- I read the contribution guidelines.
- I created `DocumentsNotFoundError` to aggregate multiple documents not being found.
- I don't believe `delete_many` should typically raise `DocumentsNotFoundError`, unless another thread deletes one of the instances returned from `find` before it is deleted from within `delete_many`. This should be a rare scenario typically.