### PR TITLE
_BaseODMModel.doc fix

### DIFF
--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -658,7 +658,7 @@ class _BaseODMModel(pydantic.BaseModel, metaclass=ABCMeta):
             if include is not None and field_name not in include:
                 continue
             if isinstance(field, ODMReference):
-                doc[field.key_name] = raw_doc[field_name]["id"]
+                doc[field.key_name] = raw_doc[field_name][field.model.__primary_field__]
             else:
                 if field_name in self.__bson_serialized_fields__:
                     doc[field.key_name] = self.__fields__[field_name].type_.__bson__(


### PR DESCRIPTION
Fix _BaseODMModel.doc containing referenced models with primary_field != id

For example:
```
class X(Model):
    key: str = Field(primary_field=True)

class Y(Model):
    x_referenced: X = Reference()
```

Saving Y model previously would not work, due to expecting the reference property "x_referenced" to have a property "id"