### PR TITLE
Update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ next step.
 > terminate the MongoDB instance and remove the container).
 >
 > ```shell
-> docker run --rm --net=host mongo
+> docker run --rm -p 27017:27017 mongo
 > ```
 
 First, let's connect to the database using the engine. In ODMantic, every database


### PR DESCRIPTION
`--net=host` doesn't work for Mac



To quote from https://docs.docker.com/network/host/ :

> The host networking driver only works on Linux hosts, and is not supported on Docker for Mac, Docker for Windows, or Docker EE for Windows Server.