### PR TITLE
Create new types instead of changing type args for structural types

### DIFF
--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -6,7 +6,7 @@ import uuid
 import warnings
 from abc import ABCMeta
 from collections.abc import Callable as abcCallable
-from types import FunctionType
+from types import FunctionType, GenericAlias
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -178,7 +178,7 @@ def validate_type(type_: Type) -> Type:
     if type_origin is not None:
         type_args: Tuple[Type, ...] = getattr(type_, "__args__", ())
         new_arg_types = tuple(validate_type(subtype) for subtype in type_args)
-        setattr(type_, "__args__", new_arg_types)
+        type_ = GenericAlias(type_origin, new_arg_types)
         if USES_OLD_TYPING_INTERFACE:
             # FIXME: there is probably a more elegant way of doing this
             subs_tree = type_._subs_tree()

--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -6,7 +6,7 @@ import uuid
 import warnings
 from abc import ABCMeta
 from collections.abc import Callable as abcCallable
-from types import FunctionType, GenericAlias
+from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -14,6 +14,7 @@ from typing import (
     ClassVar,
     Dict,
     FrozenSet,
+    _GenericAlias,
     Iterable,
     List,
     Optional,
@@ -178,7 +179,7 @@ def validate_type(type_: Type) -> Type:
     if type_origin is not None:
         type_args: Tuple[Type, ...] = getattr(type_, "__args__", ())
         new_arg_types = tuple(validate_type(subtype) for subtype in type_args)
-        type_ = GenericAlias(type_origin, new_arg_types)
+        type_ = _GenericAlias(type_origin, new_arg_types)
         if USES_OLD_TYPING_INTERFACE:
             # FIXME: there is probably a more elegant way of doing this
             subs_tree = type_._subs_tree()


### PR DESCRIPTION
This avoids changing existing types.

See #200 