### PR TITLE
🐛 Fix using the shared session when updating a document

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -73,6 +73,31 @@ There are two ways of persisting instances to the database (i.e creating new doc
     details](engine.md#update)). Hence, you might overwrite documents if you save
     instances with an existing primary key already existing in the database.
 
+### Using a Session
+
+When you save one or multiple instances, a session is created and used automatically.
+
+But you can also create a session yourself and pass it as a parameter to [AIOEngine.save][odmantic.engine.AIOEngine.save] and [AIOEngine.save_all][odmantic.engine.AIOEngine.save].
+
+For example:
+
+```python linenums="1" hl_lines="13-14  22-23"
+--8<-- "engine/create_with_session.py"
+```
+
+The `engine.client` attribute of an `AIOEngine` instance is the [AsyncIOMotorClient](https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_client.html){:target=blank_} used internally. So, you can access its attributes and methods, in this case, to create a session.
+
+### Using a Transaction
+
+The same way that you can create a session, you can also start a transaction for your operations:
+
+```python linenums="1" hl_lines="14  24"
+--8<-- "engine/create_with_transaction.py"
+```
+
+!!! warning "Transaction support in MongoDB"
+    Have in mind that transactions are only supported in a replica set or `mongos`, if you use them in a standalone MongoDB instance you will get an error.
+
 ## Read
 
 !!! note "Examples database content"

--- a/docs/examples_src/engine/create_with_session.py
+++ b/docs/examples_src/engine/create_with_session.py
@@ -1,0 +1,23 @@
+from odmantic import AIOEngine, Model
+
+
+class Player(Model):
+    name: str
+    game: str
+
+
+engine = AIOEngine()
+
+leeroy = Player(name="Leeroy Jenkins", game="World of Warcraft")
+
+async with await engine.client.start_session() as session:
+    await engine.save(leeroy, session=session)
+
+players = [
+    Player(name="Shroud", game="Counter-Strike"),
+    Player(name="Serral", game="Starcraft"),
+    Player(name="TLO", game="Starcraft"),
+]
+
+async with await engine.client.start_session() as session:
+    await engine.save_all(players)

--- a/docs/examples_src/engine/create_with_session.py
+++ b/docs/examples_src/engine/create_with_session.py
@@ -20,4 +20,4 @@ players = [
 ]
 
 async with await engine.client.start_session() as session:
-    await engine.save_all(players)
+    await engine.save_all(players, session=session)

--- a/docs/examples_src/engine/create_with_transaction.py
+++ b/docs/examples_src/engine/create_with_transaction.py
@@ -22,4 +22,4 @@ players = [
 
 async with await engine.client.start_session() as session:
     async with session.start_transaction():
-        await engine.save_all(players)
+        await engine.save_all(players, session=session)

--- a/docs/examples_src/engine/create_with_transaction.py
+++ b/docs/examples_src/engine/create_with_transaction.py
@@ -1,0 +1,25 @@
+from odmantic import AIOEngine, Model
+
+
+class Player(Model):
+    name: str
+    game: str
+
+
+engine = AIOEngine()
+
+leeroy = Player(name="Leeroy Jenkins", game="World of Warcraft")
+
+async with await engine.client.start_session() as session:
+    async with session.start_transaction():
+        await engine.save(leeroy, session=session)
+
+players = [
+    Player(name="Shroud", game="Counter-Strike"),
+    Player(name="Serral", game="Starcraft"),
+    Player(name="TLO", game="Starcraft"),
+]
+
+async with await engine.client.start_session() as session:
+    async with session.start_transaction():
+        await engine.save_all(players)

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -316,6 +316,7 @@ class AIOEngine:
                 {"_id": getattr(instance, instance.__primary_field__)},
                 {"$set": doc},
                 upsert=True,
+                session=session,
             )
             object.__setattr__(instance, "__fields_modified__", set())
         return instance

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -334,8 +334,8 @@ class AIOEngine:
             instance: instance to persist
             session: An optional `AsyncIOMotorClientSession` to use, if not provided
                 one will be created. This could be used to start a transaction (only
-                supported in sharded or clustered MongoDB deployments) and then
-                pass the session with the transaction here.
+                supported in a MongoDB cluster with replicas) and then pass the session
+                with the transaction here.
 
         Returns:
             the saved instance
@@ -355,7 +355,6 @@ class AIOEngine:
         else:
             async with await self.client.start_session() as local_session:
                 await self._save(instance, local_session)
-
         return instance
 
     async def save_all(
@@ -376,8 +375,8 @@ class AIOEngine:
             instances: instances to persist
             session: An optional `AsyncIOMotorClientSession` to use, if not provided
                 one will be created. This could be used to start a transaction (only
-                supported in sharded or clustered MongoDB deployments) and then
-                pass the session with the transaction here.
+                supported in a MongoDB cluster with replicas) and then pass the session
+                with the transaction here.
 
         Returns:
             the saved instances

--- a/tests/integration/test_engine_reference.py
+++ b/tests/integration/test_engine_reference.py
@@ -12,7 +12,7 @@ from ..zoo.book_reference import Book, Publisher
 
 pytestmark = pytest.mark.asyncio
 only_on_replica = pytest.mark.skipif(
-    TEST_MONGO_MODE not in {MongoMode.REPLICA, MongoMode.SHARDED},
+    TEST_MONGO_MODE != MongoMode.REPLICA,
     reason="Test transactions only with replicas/shards, as it's only supported there",
 )
 

--- a/tests/integration/test_engine_reference.py
+++ b/tests/integration/test_engine_reference.py
@@ -62,6 +62,10 @@ async def test_save_deeply_nested_and_fetch(engine: AIOEngine):
 
 @only_on_replica
 async def test_save_deeply_nested_and_fetch_with_transaction(engine: AIOEngine):
+    await engine.database.create_collection(engine.get_collection(NestedLevel1).name)
+    await engine.database.create_collection(engine.get_collection(NestedLevel2).name)
+    await engine.database.create_collection(engine.get_collection(NestedLevel3).name)
+
     instance = NestedLevel1(next_=NestedLevel2(next_=NestedLevel3(field=0)))
     async with await engine.client.start_session() as session:
         async with session.start_transaction():
@@ -92,6 +96,9 @@ async def test_multiple_save_deeply_nested_and_fetch_with_transaction(
         NestedLevel1(field=1, next_=NestedLevel2(field=2, next_=NestedLevel3(field=3))),
         NestedLevel1(field=4, next_=NestedLevel2(field=5, next_=NestedLevel3(field=6))),
     ]
+    await engine.database.create_collection(engine.get_collection(NestedLevel1).name)
+    await engine.database.create_collection(engine.get_collection(NestedLevel2).name)
+    await engine.database.create_collection(engine.get_collection(NestedLevel3).name)
     async with await engine.client.start_session() as session:
         async with session.start_transaction():
             await engine.save_all(instances, session=session)

--- a/tests/integration/test_engine_reference.py
+++ b/tests/integration/test_engine_reference.py
@@ -5,11 +5,16 @@ from odmantic.engine import AIOEngine
 from odmantic.exceptions import DocumentParsingError
 from odmantic.model import Model
 from odmantic.reference import Reference
+from tests.integration.conftest import TEST_MONGO_MODE, MongoMode
 from tests.zoo.deeply_nested import NestedLevel1, NestedLevel2, NestedLevel3
 
 from ..zoo.book_reference import Book, Publisher
 
 pytestmark = pytest.mark.asyncio
+only_on_replica = pytest.mark.skipif(
+    TEST_MONGO_MODE not in {MongoMode.REPLICA, MongoMode.SHARDED},
+    reason="Test transactions only with replicas/shards, as it's only supported there",
+)
 
 
 async def test_add_with_references(engine: AIOEngine):
@@ -55,12 +60,41 @@ async def test_save_deeply_nested_and_fetch(engine: AIOEngine):
     assert fetched == instance
 
 
+@only_on_replica
+async def test_save_deeply_nested_and_fetch_with_transaction(engine: AIOEngine):
+    instance = NestedLevel1(next_=NestedLevel2(next_=NestedLevel3(field=0)))
+    async with await engine.client.start_session() as session:
+        async with session.start_transaction():
+            await engine.save(instance, session=session)
+
+    fetched = await engine.find_one(NestedLevel1)
+    assert fetched == instance
+
+
 async def test_multiple_save_deeply_nested_and_fetch(engine: AIOEngine):
     instances = [
         NestedLevel1(field=1, next_=NestedLevel2(field=2, next_=NestedLevel3(field=3))),
         NestedLevel1(field=4, next_=NestedLevel2(field=5, next_=NestedLevel3(field=6))),
     ]
     await engine.save_all(instances)
+
+    fetched = await engine.find(NestedLevel1)
+    assert len(fetched) == 2
+    assert fetched[0] in instances
+    assert fetched[1] in instances
+
+
+@only_on_replica
+async def test_multiple_save_deeply_nested_and_fetch_with_transaction(
+    engine: AIOEngine,
+):
+    instances = [
+        NestedLevel1(field=1, next_=NestedLevel2(field=2, next_=NestedLevel3(field=3))),
+        NestedLevel1(field=4, next_=NestedLevel2(field=5, next_=NestedLevel3(field=6))),
+    ]
+    async with await engine.client.start_session() as session:
+        async with session.start_transaction():
+            await engine.save_all(instances, session=session)
 
     fetched = await engine.find(NestedLevel1)
     assert len(fetched) == 2

--- a/tests/integration/test_engine_reference.py
+++ b/tests/integration/test_engine_reference.py
@@ -62,6 +62,8 @@ async def test_save_deeply_nested_and_fetch(engine: AIOEngine):
 
 @only_on_replica
 async def test_save_deeply_nested_and_fetch_with_transaction(engine: AIOEngine):
+    # Before MongoDB 4.4 it's necessary to create the collections before trying to use
+    # them inside a transaction
     await engine.database.create_collection(engine.get_collection(NestedLevel1).name)
     await engine.database.create_collection(engine.get_collection(NestedLevel2).name)
     await engine.database.create_collection(engine.get_collection(NestedLevel3).name)
@@ -92,13 +94,15 @@ async def test_multiple_save_deeply_nested_and_fetch(engine: AIOEngine):
 async def test_multiple_save_deeply_nested_and_fetch_with_transaction(
     engine: AIOEngine,
 ):
+    # Before MongoDB 4.4 it's necessary to create the collections before trying to use
+    # them inside a transaction
+    await engine.database.create_collection(engine.get_collection(NestedLevel1).name)
+    await engine.database.create_collection(engine.get_collection(NestedLevel2).name)
+    await engine.database.create_collection(engine.get_collection(NestedLevel3).name)
     instances = [
         NestedLevel1(field=1, next_=NestedLevel2(field=2, next_=NestedLevel3(field=3))),
         NestedLevel1(field=4, next_=NestedLevel2(field=5, next_=NestedLevel3(field=6))),
     ]
-    await engine.database.create_collection(engine.get_collection(NestedLevel1).name)
-    await engine.database.create_collection(engine.get_collection(NestedLevel2).name)
-    await engine.database.create_collection(engine.get_collection(NestedLevel3).name)
     async with await engine.client.start_session() as session:
         async with session.start_transaction():
             await engine.save_all(instances, session=session)


### PR DESCRIPTION
🐛 Fix using the shared session when updating a document

Currently, the code creates a session and transaction and passes down the session in the parameters through all the function calls, but it's not passed in the last point, which would make motor use the session.

The original intention of this PR was just to pass that `session`, a one-line/argument change, but I found a couple of bugs and caveats along the way and the PR got bigger.

~I'm not sure I should add tests for this, I was trying to add them but I saw that I would have to add a bunch of mocks for the internals, or add strange tricks to break the save in the middle and see that the session didn't finish... but then any of those things seemed like a very complex trick to enable a test that would mostly test the trick, and not really the session. Not sure if I should do anything else. Let me know!~

## Edit 2022-06-23 Transactions in Standalone

I see that transactions are only supported in MongoDB clusters with shards or replicas. And there's no simple way to detect the type of cluster in code. When using a transaction on a standalone MongoDB I get this error:

```
pymongo.errors.OperationFailure: Transaction numbers are only allowed on a replica set member or mongos, full error: {'ok': 0.0, 'errmsg': 'Transaction numbers are only allowed on a replica set member or mongos', 'code': 20, 'codeName': 'IllegalOperation'}
```

That error is currently not being thrown because sessions are currently not used (which is what this intends to fix).

Detecting if the current cluster is replicated, sharded, or standalone (unsupported) would require a lot of complex and fragile logic, as even though transactions are not supported in standalone, there's no way to ask the cluster what's the current type of deployment.

To solve that, I moved the transactions away from the internal code (they were not used anyway), and added support for passing a session to `engine.save()` and `engine.save_all()`, this way, a user could create a session outside, create a transaction (after confirming they have a supported deployment) and then pass the session to these methods.

## Edit 2022-06-23 B Same session concurrently

I'm seeing that the same session is not expected to be used concurrently 😔 

https://motor.readthedocs.io/en/3.0.0/api-asyncio/asyncio_motor_client.html#motor.motor_asyncio.AsyncIOMotorClient.start_session

> Do **not** use the same session for multiple operations concurrently.

So using `asyncio.gather()` should not be used as the document saves are expected to share the same session.

## Edit 2022-06-24 Tests for transactions

I added a couple of tests to confirm that external transactions work with `engine.save()` and `engine.save_all()`. Because transactions require a cluster with replicas, those tests are only run on the replica version.