### PR TITLE
✨ Upgrade types and add support for instance autocompletion with dataclass_transform (VS Code autocompletion), drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
@@ -61,7 +60,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,13 @@ repos:
       - id: isort
         exclude: "^docs/.*"
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.961
     hooks:
       - id: mypy
         exclude: "^docs/.*"
         additional_dependencies:
           - pydantic~=1.9.1
+          - motor~=3.0.0
         args: [--no-pretty, --show-error-codes]
   - repo: https://gitlab.com/pycqa/flake8.git
     rev: "3.8.3"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
         additional_dependencies:
           - pydantic~=1.9.1
           - motor~=3.0.0
+          - types-pytz~=2022.1.1
         args: [--no-pretty, --show-error-codes]
   - repo: https://gitlab.com/pycqa/flake8.git
     rev: "3.8.3"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <a href="https://codecov.io/gh/art049/odmantic" target="_blank">
     <img src="https://codecov.io/gh/art049/odmantic/branch/master/graph/badge.svg?token=3NYZK14STZ" alt="coverage">
 </a>
-<img src="https://img.shields.io/badge/python-3.6%20|%203.7%20|%203.8%20|%203.9-informational.svg" alt="python-3.6-3.7-3.8">
+<img src="https://img.shields.io/badge/python-3.7%20|%203.8%20|%203.9-informational.svg" alt="python-3.7-3.8">
 <a href="https://pypi.org/project/odmantic" target="_blank">
     <img src="https://img.shields.io/pypi/v/odmantic?color=%2334D058&label=pypi" alt="Package version">
 </a>
@@ -47,7 +47,7 @@ Core features:
 
 ## Requirements
 
-**Python**: 3.6.1 and later (tested against 3.6, 3.7, 3.8 and 3.9)
+**Python**: 3.7 and later (tested against 3.7, 3.8 and 3.9)
 
 **MongoDB**: 4.0 and later
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,12 +102,11 @@ Here are the steps:
 
     ```shell
     # Install the versions
-    pyenv install "3.6.12"
     pyenv install "3.7.9"
     pyenv install "3.8.9"
     pyenv install "3.9.0"
     # Make the versions available locally in the project
-    pyenv local 3.8.6 3.7.9 3.6.12 3.9.0
+    pyenv local 3.8.6 3.7.9 3.9.0
     ```
 
 #### Configuring the local environment

--- a/odmantic/bson.py
+++ b/odmantic/bson.py
@@ -1,7 +1,7 @@
 import decimal
 import re
 from datetime import datetime
-from typing import Any, Dict, Pattern, cast
+from typing import Any, Dict, Pattern
 
 import bson
 import bson.binary
@@ -169,7 +169,7 @@ class _decimalDecimal(decimal.Decimal):
         if isinstance(v, decimal.Decimal):
             return v
         elif isinstance(v, bson.decimal128.Decimal128):
-            return cast(decimal.Decimal, v.to_decimal())
+            return v.to_decimal()
 
         a = decimal_validator(v)
         return a

--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -36,6 +36,7 @@ from pydantic.main import BaseModel
 from pydantic.tools import parse_obj_as
 from pydantic.typing import is_classvar, resolve_annotations
 from pydantic.utils import lenient_issubclass
+from typing_extensions import dataclass_transform
 
 from odmantic.bson import (
     _BSON_SUBSTITUTED_FIELDS,
@@ -51,6 +52,7 @@ from odmantic.exceptions import (
     ReferencedDocumentNotFoundError,
 )
 from odmantic.field import (
+    Field,
     FieldProxy,
     ODMBaseField,
     ODMEmbedded,
@@ -372,6 +374,7 @@ class BaseModelMetaclass(pydantic.main.ModelMetaclass):
         return cls
 
 
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field, ODMFieldInfo))
 class ModelMetaclass(BaseModelMetaclass):
     @no_type_check
     def __new__(  # noqa C901
@@ -433,6 +436,7 @@ class ModelMetaclass(BaseModelMetaclass):
         return cast(str, getattr(cls, "__collection__"))
 
 
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field, ODMFieldInfo))
 class EmbeddedModelMetaclass(BaseModelMetaclass):
     @no_type_check
     def __new__(

--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -751,7 +751,7 @@ class Model(_BaseODMModel, metaclass=ModelMetaclass):
         __collection__: ClassVar[str] = ""
         __primary_field__: ClassVar[str] = ""
 
-        id: Union[ObjectId, Any]  # TODO fix basic id field typing
+        id: Union[ObjectId, Any] = None  # TODO fix basic id field typing
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name == self.__primary_field__:

--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -142,7 +142,7 @@ def is_type_mutable(type_: Type) -> bool:
         return not lenient_issubclass(type_origin, _IMMUTABLE_TYPES)
     else:
         return not (
-            type_ is None  # type:ignore
+            type_ is None
             or (
                 lenient_issubclass(type_, _IMMUTABLE_TYPES)
                 and not lenient_issubclass(type_, EmbeddedModel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<1.10.0",
     "motor >=2.1.0,<3.1.0",
     "importlib-metadata >=1,<5; python_version<'3.8'",
-    "typing-extensions >= 3.7.4.3; python_version<'3.8'",
+    "typing-extensions >= 4.1.0; python_version<'3.11'",
 ]
 [project.optional-dependencies]
 fastapi = ["fastapi >=0.61.1,<0.69.0"]
@@ -46,7 +46,7 @@ test = [
     "black ~= 22.3.0",
     "isort ~=5.8.0",
     "flake8 ~= 4.0.1",
-    "mypy ~= 0.942",
+    "mypy ~= 0.961",
     "pytest ~= 7.0",
     "pytest-xdist ~= 2.1.0",
     "pytest-asyncio ~= 0.16.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
     "requests ~= 2.24.0",
     "typer ~= 0.4.1",
     "semver ~= 2.13.0",
+    "types-pytz ~= 2022.1.1",
 ]
 doc = [
     "pydocstyle ~= 6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<1.10.0",
     "motor >=2.1.0,<3.1.0",
     "importlib-metadata >=1,<5; python_version<'3.8'",
-    "typing-extensions >= 4.1.0; python_version<'3.11'",
+    "typing-extensions >= 4.2.0; python_version<'3.11'",
 ]
 [project.optional-dependencies]
 fastapi = ["fastapi >=0.61.1,<0.69.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "License :: OSI Approved :: ISC License (ISCL)",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -33,7 +32,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 
-requires-python = ">=3.6.1"
+requires-python = ">=3.7"
 dependencies = [
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<1.10.0",
     "motor >=2.1.0,<3.1.0",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ from odmantic.engine import AIOEngine
 try:
     from unittest.mock import AsyncMock
 except ImportError:
-    from mock import AsyncMock
+    from mock import AsyncMock  # type: ignore
 
 TEST_MONGO_URI: str = os.getenv("TEST_MONGO_URI", "mongodb://localhost:27017/")
 

--- a/tests/integration/test_types.py
+++ b/tests/integration/test_types.py
@@ -81,7 +81,7 @@ async def test_bson_type_inference(
     instance = await engine.save(ModelWithTypedField(field=case.sample_value))
     document = await motor_database[ModelWithTypedField.__collection__].find_one(
         {
-            +ModelWithTypedField.id: instance.id,
+            +ModelWithTypedField.id: instance.id,  # type: ignore
             +ModelWithTypedField.field: {"$type": case.bson_type},
         }
     )
@@ -116,7 +116,7 @@ async def test_custom_bson_serializable(
     instance = await engine.save(ModelWithCustomField(field=3.14))
     document = await motor_database[ModelWithCustomField.__collection__].find_one(
         {
-            +ModelWithCustomField.id: instance.id,
+            +ModelWithCustomField.id: instance.id,  # type: ignore
             +ModelWithCustomField.field: {"$type": "string"},  # type: ignore
         }
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 isolated_build = true
 envlist =
-    py{36}-motor{23,24,25}-pydantic{16,17,18}
     py{37,38,39}-motor{21,22,23,24,25,30}-pydantic{17,18,19}
 skip_missing_interpreters=false
 [testenv]
@@ -13,7 +12,6 @@ deps =
     motor24: motor ~= 2.4.0
     motor25: motor ~= 2.5.0
     motor30: motor ~= 3.0.0
-    pydantic16: pydantic ~= 1.6.2
     pydantic17: pydantic ~= 1.7.4
     pydantic18: pydantic ~= 1.8.2
     pydantic19: pydantic ~= 1.9.0


### PR DESCRIPTION
✨ Upgrade types and add support for instance autocompletion with dataclass_transform (VS Code autocompletion).

This is more or less the same as: https://github.com/art049/odmantic/pull/229, and this PR would superseded that one (if accepted). This PR upgrades mypy, the pre-commit, typing-extensions, the necessary types for the new mypy, and adds again `dataclass_transform` with the definitive version (importing from `typing`).

**Edit 2022-06-23**: I realized that the new parameters for `dataclass_transform` require `typing_extensions` version `4.2.0`, but that version doesn't have support for Python 3.6. So this specific PR would depend on dropping support for Python 3.6. 🤦 