### PR TITLE
 Create new types instead of changing type args for structural types

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version=3.8
+python_version=3.9
 pretty=True
 follow_imports=normal
 ignore_missing_imports=True

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -19,7 +19,6 @@ from typing import (
 )
 
 import pymongo
-from pydantic.utils import lenient_issubclass
 from pymongo import MongoClient
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -39,6 +38,7 @@ from odmantic.session import (
     SyncSessionBase,
     SyncTransaction,
 )
+from odmantic.typing import lenient_issubclass
 
 try:
     import motor

--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -36,7 +36,6 @@ from pydantic.fields import Undefined
 from pydantic.main import BaseModel
 from pydantic.tools import parse_obj_as
 from pydantic.typing import is_classvar, resolve_annotations
-from pydantic.utils import lenient_issubclass
 
 from odmantic.bson import (
     _BSON_SUBSTITUTED_FIELDS,
@@ -72,6 +71,7 @@ from odmantic.typing import (
     get_first_type_argument_subclassing,
     get_origin,
     is_type_argument_subclass,
+    lenient_issubclass,
 )
 from odmantic.utils import (
     is_dunder,

--- a/odmantic/query.py
+++ b/odmantic/query.py
@@ -27,7 +27,7 @@ class QueryExpression(Dict[str, Any]):
             parent_repr = ""
         return f"QueryExpression({parent_repr})"
 
-    def __or__(self, other: "QueryExpression") -> "QueryExpression":
+    def __or__(self, other: "QueryExpression") -> "QueryExpression":  # type: ignore
         return or_(self, other)
 
     def __and__(self, other: "QueryExpression") -> "QueryExpression":

--- a/odmantic/typing.py
+++ b/odmantic/typing.py
@@ -38,3 +38,7 @@ def get_first_type_argument_subclassing(
         if lenient_issubclass(arg, cls):
             return arg
     return None
+
+
+USES_OLD_TYPING_INTERFACE = sys.version_info[:3] < (3, 7, 0)  # PEP 560
+HAS_GENERIC_ALIAS_BUILTIN = sys.version_info[:3] >= (3, 9, 0)  # PEP 560

--- a/odmantic/typing.py
+++ b/odmantic/typing.py
@@ -19,6 +19,12 @@ else:
     # FIXME: add this back to coverage once 3.11 is released
     from typing import dataclass_transform  # noqa: F401 # pragma: no cover
 
+HAS_GENERIC_ALIAS_BUILTIN = sys.version_info[:3] >= (3, 9, 0)  # PEP 560
+if HAS_GENERIC_ALIAS_BUILTIN:
+    from typing import GenericAlias  # type: ignore
+else:
+    from typing import _GenericAlias as GenericAlias  # type: ignore # noqa: F401
+
 
 def is_type_argument_subclass(
     type_: Type, class_or_tuple: Union[Type[Any], Tuple[Type[Any], ...], None]
@@ -38,7 +44,3 @@ def get_first_type_argument_subclassing(
         if lenient_issubclass(arg, cls):
             return arg
     return None
-
-
-USES_OLD_TYPING_INTERFACE = sys.version_info[:3] < (3, 7, 0)  # PEP 560
-HAS_GENERIC_ALIAS_BUILTIN = sys.version_info[:3] >= (3, 9, 0)  # PEP 560

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ filterwarnings = [
     "ignore:\"@coroutine\" decorator is deprecated.*:DeprecationWarning:motor.*",
     "ignore:the AIOEngineDependency object is deprecated.*:DeprecationWarning:odmantic.*",
 ]
-
+pythonpath = "src tests"
 [tool.coverage.run]
 branch = true
 [tool.coverage.report]

--- a/tests/integration/test_types.py
+++ b/tests/integration/test_types.py
@@ -2,7 +2,7 @@ import dataclasses
 import re
 from datetime import datetime
 from decimal import Decimal
-from typing import Dict, Generic, List, Pattern, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Pattern, Tuple, Type, TypeVar, Union
 
 import pytest
 from bson import Binary, Decimal128, Int64, ObjectId, Regex
@@ -47,7 +47,7 @@ type_test_data = [
         Decimal, "decimal", "3.14159265359"
     ),  # TODO split tests for  odmantic type inference
     TypeTestCase(Decimal128, "decimal", Decimal128(Decimal("3.14159265359"))),
-    TypeTestCase(Dict, "object", {"foo": "bar", "fizz": {"foo": "bar"}}),
+    TypeTestCase(Dict[str, Any], "object", {"foo": "bar", "fizz": {"foo": "bar"}}),
     TypeTestCase(bool, "bool", False),
     TypeTestCase(Pattern, "regex", re.compile(r"^.*$")),
     TypeTestCase(Pattern, "regex", re.compile(r"^.*$", flags=re.IGNORECASE)),
@@ -59,7 +59,7 @@ type_test_data = [
     TypeTestCase(bytes, "binData", b"\xf0\xf1\xf2"),
     TypeTestCase(Binary, "binData", Binary(b"\xf0\xf1\xf2")),
     TypeTestCase(datetime, "date", sample_datetime),
-    TypeTestCase(List, "array", ["one"]),
+    TypeTestCase(List[str], "array", ["one"]),
     # Compound Types
     TypeTestCase(Tuple[str, ...], "array", ("one",)),  # type: ignore
     TypeTestCase(List[ObjectId], "array", [ObjectId() for _ in range(5)]),

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -1,0 +1,19 @@
+from typing import Dict, List, Set, Tuple
+
+from typing_utils import are_generics_equal
+
+
+def test_are_generics_equal_two_different_origin():
+    assert not are_generics_equal(List[str], Set[str])
+
+
+def test_are_generics_equal_different_arg_count():
+    assert not are_generics_equal(Tuple[str], Tuple[str, str])
+    assert not are_generics_equal(Tuple[str], Tuple[str, ...])
+
+
+def test_are_generics_equal_different_args():
+    assert not are_generics_equal(Tuple[str, int], Tuple[int, str])
+    assert not are_generics_equal(
+        Tuple[str, int, Dict[int, str]], Tuple[str, int, Dict[int, int]]
+    )

--- a/tests/typing_utils.py
+++ b/tests/typing_utils.py
@@ -1,0 +1,18 @@
+from typing import Type
+
+from odmantic.typing import get_args, get_origin
+
+
+def are_generics_equal(g1: Type, g2: Type) -> bool:
+    """Check if two generic types are equal."""
+    if g1 == g2:
+        return True
+    origin_g1 = get_origin(g1)
+    origin_g2 = get_origin(g2)
+    if origin_g1 is None or origin_g2 is None or origin_g1 != origin_g2:
+        return False
+    args_g1 = get_args(g1)
+    args_g2 = get_args(g2)
+    if len(args_g1) != len(args_g2):
+        return False
+    return all(are_generics_equal(a1, a2) for a1, a2 in zip(args_g1, args_g2))

--- a/tests/unit/test_model_type_validation.py
+++ b/tests/unit/test_model_type_validation.py
@@ -13,6 +13,7 @@ from typing import (
 
 import bson
 import pytest
+from typing_utils import are_generics_equal
 
 from odmantic.bson import (
     _BSON_SUBSTITUTED_FIELDS,
@@ -32,13 +33,15 @@ def test_validate_type_bson_substituted(base, replacement):
 
 @pytest.mark.parametrize("base, replacement", _BSON_SUBSTITUTED_FIELDS.items())
 def test_optional_bson_subst(base, replacement):
-    assert validate_type(Optional[base]) == Optional[replacement]  # type: ignore
+    assert are_generics_equal(
+        validate_type(Optional[base]), Optional[replacement]  # type: ignore
+    )
 
 
 @pytest.mark.parametrize("origin", (List, Set, FrozenSet, Sequence))
 @pytest.mark.parametrize("base, replacement", _BSON_SUBSTITUTED_FIELDS.items())
 def test_single_arg_type_bson_subst(origin, base, replacement):
-    assert validate_type(origin[base]) == origin[replacement]
+    assert are_generics_equal(validate_type(origin[base]), origin[replacement])
 
 
 def test_forbidden_field():
@@ -47,17 +50,17 @@ def test_forbidden_field():
 
 
 def test_deep_nest_bson_subst():
-    assert (
+    assert are_generics_equal(
         validate_type(
             Union[  # type: ignore
                 Dict[List[bson.ObjectId], Dict[bson.ObjectId, bson.Decimal128]],
                 Dict[Dict[Set[bson.Int64], bson.Binary], Tuple[bson.Regex, ...]],
             ]
-        )
-        == Union[
+        ),
+        Union[
             Dict[List[ObjectId], Dict[ObjectId, Decimal128]],
             Dict[Dict[Set[Int64], Binary], Tuple[Regex, ...]],
-        ]
+        ],
     )
 
 


### PR DESCRIPTION
Continues #220 created by @erny 
Closes #200 and will fix #66 

Type equality tests are failing because of https://github.com/python/cpython/issues/97543