### PR TITLE
👷 Pin tox to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             .tox
           key: env-compatibility-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Install tox
-        run: pip install tox flit
+        run: pip install "tox~=3.27.1" flit
       - name: Run compatibility checks.
         run: |
           export VERSION_STR=$(echo ${{ matrix.python-version }} | sed -e "s/\.//g")


### PR DESCRIPTION
👷 Pin tox to fix CI

It seems CI is currently failing because `tox` probably introduced an incompatibility in a recent release: https://tox.wiki/en/latest/faq.html#breaking-changes-in-tox-4

I don't know what the problem is, I'm not familiar with Tox, but this PR pins tox to the latest `3.x.x` version available to fix CI that currently is failing.