### PR TITLE
feat: codec options argument for engine initialization

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -12,6 +12,8 @@ In the previous examples, we created the engine using default parameters:
 
 It's possible to provide a custom client ([AsyncIOMotorClient](https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_client.html){:target=blank_} or [PyMongoClient](https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html){:target=blank_}) to the engine constructor. In the same way, the database name can be changed using the `database` keyword argument.
 
+It is also possible to define the database [`codec_options`](https://pymongo.readthedocs.io/en/stable/api/bson/codec_options.html#module-bson.codec_options) to adjust some conversions, such as parsing _datetime_ information with timezone awareness (`pymongo` works with naive UTC `datetime.datetime` by default). 
+
 {{ async_sync_snippet("engine", "engine_creation.py") }}
 
 For additional information about the MongoDB connection strings, see [this

--- a/docs/examples_src/engine/async/engine_creation.py
+++ b/docs/examples_src/engine/async/engine_creation.py
@@ -1,6 +1,13 @@
+from datetime import timezone
+
+from bson import CodecOptions
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from odmantic import AIOEngine
 
 client = AsyncIOMotorClient("mongodb://localhost:27017/")
-engine = AIOEngine(client=client, database="example_db")
+engine = AIOEngine(
+    client=client, 
+    database="example_db", 
+    codec_options=CodecOptions(tz_aware=True, tzinfo=timezone.utc),
+) 

--- a/docs/examples_src/engine/sync/engine_creation.py
+++ b/docs/examples_src/engine/sync/engine_creation.py
@@ -1,6 +1,13 @@
+from datetime import timezone
+
+from bson import CodecOptions
 from pymongo import MongoClient
 
 from odmantic import SyncEngine
 
 client = MongoClient("mongodb://localhost:27017/")
-engine = SyncEngine(client=client, database="example_db")
+engine = SyncEngine(
+    client=client, 
+    database="example_db", 
+    codec_options=CodecOptions(tz_aware=True, tzinfo=timezone.utc),
+) 

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -18,6 +18,7 @@ from typing import (
     cast,
 )
 
+from bson import CodecOptions
 import pymongo
 from pymongo import MongoClient
 from pymongo.client_session import ClientSession
@@ -164,6 +165,7 @@ class BaseEngine:
         self,
         client: Union["AsyncIOMotorClient", "MongoClient"],
         database: str = "test",
+        codec_options: Optional[CodecOptions] = None,
     ):
         # https://docs.mongodb.com/manual/reference/limits/#naming-restrictions
         forbidden_characters = _FORBIDDEN_DATABASE_CHARACTERS.intersection(
@@ -175,7 +177,7 @@ class BaseEngine:
             )
         self.client = client
         self.database_name = database
-        self.database = client[self.database_name]
+        self.database = client.get_database(self.database_name, codec_options)
 
     @staticmethod
     def _build_query(*queries: Union[QueryExpression, Dict, bool]) -> QueryExpression:
@@ -304,6 +306,7 @@ class AIOEngine(BaseEngine):
         self,
         client: Union["AsyncIOMotorClient", None] = None,
         database: str = "test",
+        codec_options: Optional[CodecOptions] = None,
     ):
         """Engine constructor.
 
@@ -323,7 +326,7 @@ class AIOEngine(BaseEngine):
             )
         if client is None:
             client = AsyncIOMotorClient()
-        super().__init__(client=client, database=database)
+        super().__init__(client=client, database=database, codec_options=codec_options)
 
     def get_collection(self, model: Type[ModelType]) -> "AsyncIOMotorCollection":
         """Get the motor collection associated to a Model.
@@ -724,6 +727,7 @@ class SyncEngine(BaseEngine):
         self,
         client: "Union[MongoClient, None]" = None,
         database: str = "test",
+        codec_options: Optional[CodecOptions] = None,
     ):
         """Engine constructor.
 
@@ -734,7 +738,7 @@ class SyncEngine(BaseEngine):
         """
         if client is None:
             client = MongoClient()
-        super().__init__(client=client, database=database)
+        super().__init__(client=client, database=database, codec_options=codec_options)
 
     def get_collection(self, model: Type[ModelType]) -> "Collection":
         """Get the pymongo collection associated to a Model.


### PR DESCRIPTION
The original idea was to resolve #118, which wants an easy feature to have **all** `datetime.datetime` fields as UTC-aware values.

This is definitely something very, _very_ useful, as many people (including me) consider _naive datetimes_ a source of problems. 

The proposed solution in #118 is more field-specific, but considering the issue title and the fact that most people either want timezone awareness or not (everywhere), I feel like this is the best way of getting there. 

The solution here tries to: 
- **be simple to apply**: generally, if someone is interested in timezone awareness, they will want this for all cases, so no need to configure it one by one (or maybe by document class). 
- **not break current API**: all projects already working should still work normally. 
- **allow certain flexibility**: through the `CodecOptions` object, we are able to not only define that timezone-aware _datetimes_ is what we want, but also other conversion stuff that some people may find useful. 

---

I must say that I believe that the solution could be cleaner if the `AIOEngine` and `SyncEngine` classes were not _obfuscating_ the `self.database` object generation. I was thinking of allowing an input of a full `database` object, but technically it stops making sense to input a `client`, so I had to drop the idea, as having both `client` and `database` as input arguments stops making sense (the `database` contains a reference to the client). It would be dirtier, and a possible misuse could happen.

So if there are plans for breaking the API at a certain point, it should be considered to change the initialization of these _engines_, extracting the `database` object generation out of the `BaseEngine` subclasses, to facilitate custom configurations.

Close #118 