### PR TITLE
Support model inheritance

### DIFF
--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -33,9 +33,6 @@ option in the `Config` class.
     Now, when `CapitalCity` instances will be persisted to the database, they will
     belong in the `city` collection instead of `capital_city`.
 
-!!! warning
-    Models and Embedded models inheritance is not supported yet.
-
 ### Indexes
 
 #### Index definition

--- a/odmantic/bson.py
+++ b/odmantic/bson.py
@@ -1,7 +1,7 @@
 import decimal
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, Pattern
+from typing import Any, Dict, Pattern, Type
 
 import bson
 import bson.binary
@@ -10,6 +10,7 @@ import bson.int64
 import bson.regex
 from pydantic.datetime_parse import parse_datetime
 from pydantic.main import BaseModel
+from pydantic.typing import AnyCallable
 from pydantic.validators import (
     bytes_validator,
     decimal_validator,
@@ -179,7 +180,7 @@ class _decimalDecimal(decimal.Decimal):
         return bson.decimal128.Decimal128(v)
 
 
-BSON_TYPES_ENCODERS = {
+BSON_TYPES_ENCODERS: Dict[Type[Any], AnyCallable] = {
     bson.ObjectId: str,
     bson.decimal128.Decimal128: lambda x: x.to_decimal(),  # Convert to regular decimal
     bson.regex.Regex: lambda x: x.pattern,  # TODO: document no serialization of flags

--- a/odmantic/typing.py
+++ b/odmantic/typing.py
@@ -17,12 +17,6 @@ else:
     # FIXME: add this back to coverage once 3.11 is released
     from typing import dataclass_transform  # noqa: F401 # pragma: no cover
 
-HAS_GENERIC_ALIAS_BUILTIN = sys.version_info[:3] >= (3, 9, 0)  # PEP 560
-if HAS_GENERIC_ALIAS_BUILTIN:
-    from typing import GenericAlias  # type: ignore
-else:
-    from typing import _GenericAlias as GenericAlias  # type: ignore # noqa: F401
-
 
 # Taken from https://github.com/pydantic/pydantic/pull/2392
 # Reimplemented here to avoid a dependency deprecation on pydantic1.7
@@ -32,7 +26,7 @@ def lenient_issubclass(
     try:
         return isinstance(cls, type) and issubclass(cls, class_or_tuple)
     except TypeError:
-        if isinstance(cls, GenericAlias):
+        if hasattr(cls, "__origin__"):
             return False
         raise  # pragma: no cover
 

--- a/tests/unit/test_model_inheritance.py
+++ b/tests/unit/test_model_inheritance.py
@@ -1,0 +1,197 @@
+import sys
+from typing import Any, Dict, List, Union
+
+import pytest
+
+from odmantic.field import Field
+from odmantic.model import EmbeddedModel, Model
+from odmantic.reference import Reference
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
+
+
+def get_child_model(base_model):
+    class CustomFloat(float):
+        @classmethod
+        def __bson__(cls, v):
+            return str(v)
+
+        @classmethod
+        def __get_validators__(cls):
+            yield cls.validate
+
+        @classmethod
+        def validate(cls, v):
+            return float(v)
+
+    class Referenced(Model):
+        a: int
+
+    class Parent(base_model):  # type: ignore
+        p_req: str
+        p_bson: CustomFloat
+        p_mut: Dict[str, Any] = Field(default_factory=dict)
+        p_ref: Referenced = Reference()
+
+        class Config:
+            title = "Parent"
+            anystr_strip_whitespace = True
+
+    class Child(Parent):
+        c_req: int
+        c_bson: CustomFloat
+        c_mut: List[str] = Field(default_factory=list)
+        c_ref: Referenced = Reference()
+
+        class Config:
+            collection = "children"
+            title = "Child"
+
+    return Child
+
+
+@pytest.mark.parametrize("base_model", [Model, EmbeddedModel])
+def test_model_inherited_field(base_model):
+    Child = get_child_model(base_model)
+    expected_fields = [
+        "p_req",
+        "p_bson",
+        "p_mut",
+        "p_ref",
+        "id",
+        "c_req",
+        "c_bson",
+        "c_mut",
+        "c_ref",
+    ]
+    if base_model is EmbeddedModel:
+        expected_fields.remove("id")
+    assert list(Child.__fields__.keys()) == expected_fields
+
+
+@pytest.mark.parametrize("base_model", [Model, EmbeddedModel])
+def test_model_inherited_bson_serialized_fields(base_model):
+    Child = get_child_model(base_model)
+    assert Child.__bson_serialized_fields__ == frozenset({"p_bson", "c_bson"})
+
+
+@pytest.mark.parametrize("base_model", [Model, EmbeddedModel])
+def test_model_inherited_mutable(base_model):
+    Child = get_child_model(base_model)
+    assert Child.__mutable_fields__ == frozenset({"p_mut", "c_mut"})
+
+
+@pytest.mark.parametrize("base_model", [Model, EmbeddedModel])
+def test_model_inherited_refs(base_model):
+    Child = get_child_model(base_model)
+    assert Child.__references__ == ("p_ref", "c_ref")
+
+
+@pytest.mark.parametrize("base_model", [Model, EmbeddedModel])
+def test_model_inherited_config(base_model):
+    Child = get_child_model(base_model)
+    assert Child.Config.anystr_strip_whitespace is True
+    assert Child.Config.collection == "children"
+    assert Child.Config.title == "Child"
+
+
+def test_polymorphic_model():
+    class Shape(Model):
+        area: float
+        perimeter: float
+
+        class Config:
+            collection = "shapes"
+
+    class Circle(Shape):
+        type: str = Field("circle", const=True)
+        radius: float
+
+    class Rectangle(Shape):
+        type: str = Field("rectangle", const=True)
+        width: float
+        height: float
+
+    class Table(EmbeddedModel):
+        material: str
+        shape: Shape = Reference()
+
+    tables = [
+        Table(material="steel", shape=Circle(area=3.14, perimeter=6.28, radius=1)),
+        Table(material="oak", shape=Rectangle(area=2, perimeter=6, width=1, height=2)),
+    ]
+    docs = [
+        {"material": "steel", "shape": tables[0].shape.id},
+        {"material": "oak", "shape": tables[1].shape.id},
+    ]
+    for table, doc in zip(tables, docs):
+        assert table.doc() == doc
+
+        # parse_doc expects the embedded documents, not references
+        doc["shape"] = table.shape.doc()
+        parsed_table = Table.parse_doc(doc)
+        assert parsed_table.material == table.material
+        # parsed_table.shape is an "upcasted" Shape instance of the original shape
+        assert parsed_table.shape == Shape(**table.shape.dict())
+
+
+@pytest.mark.parametrize("discriminating_union", [False, True])
+def test_polymorphic_embedded_model(discriminating_union):
+    class Shape(EmbeddedModel):
+        area: float
+        perimeter: float
+
+    class Circle(Shape):
+        type: str = Field("circle", const=True)
+        radius: float
+
+    class Rectangle(Shape):
+        type: str = Field("rectangle", const=True)
+        width: float
+        height: float
+
+    class Table(EmbeddedModel):
+        material: str
+        if discriminating_union:
+            shape: Annotated[Union[Circle, Rectangle], Field(discriminator="type")]
+        else:
+            shape: Shape  # type: ignore[no-redef]
+
+    tables = [
+        Table(material="steel", shape=Circle(area=3.14, perimeter=6.28, radius=1)),
+        Table(material="oak", shape=Rectangle(area=2, perimeter=6, width=1, height=2)),
+    ]
+    docs = [
+        {
+            "material": "steel",
+            "shape": {
+                "type": "circle",
+                "radius": 1.0,
+                "area": 3.14,
+                "perimeter": 6.28,
+            },
+        },
+        {
+            "material": "oak",
+            "shape": {
+                "type": "rectangle",
+                "width": 1.0,
+                "height": 2.0,
+                "area": 2.0,
+                "perimeter": 6.0,
+            },
+        },
+    ]
+    for table, doc in zip(tables, docs):
+        assert table.doc() == doc
+
+        parsed_table = Table.parse_doc(doc)
+        if discriminating_union:
+            assert parsed_table == table
+        else:
+            assert parsed_table.material == table.material
+            # parsed_table.shape is an "upcasted" Shape instance of the original shape
+            assert parsed_table.shape == Shape(**table.shape.dict())


### PR DESCRIPTION
Add support for model inheritance:
- The parent model(s) may extend either `odmantic.Model` or `odmantic.EmbeddedModel`.
- Class attributes added by odmantic (`__odm_fields__`, `__references__`, `__bson_serialized_fields__`, `__mutable_fields__`) are copied from the parent model(s) to the child model.
- The child `Config` inherits the parent `Config`(s) (if any).

Note: This PR is based on top of https://github.com/art049/odmantic/pull/344, here's the [actual diff](https://github.com/gsakkis/odmantic/compare/fix-optional-embedded-model...model-inheritance?expand=1). I will rebase it once the latter is merged.