### PR TITLE
Support defining multiple optional fields with different types

### DIFF
--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -194,11 +194,9 @@ def validate_type(type_: Type) -> Type:
         # generics is found
         # https://github.com/pydantic/pydantic/issues/8354
         if type_origin is Union:
-            new_root = Union[
-                int, str
-            ]  # We don't care about int,str since they will be replaced
-            setattr(new_root, "__args__", new_arg_types)
-            type_ = new_root  # type: ignore
+            # as new_arg_types is a tuple, we can directly create a matching Union instance,
+            # instead of hacking our way around it: https://stackoverflow.com/a/72884529/3784643
+            type_ = Union[new_arg_types]  # type: ignore
         else:
             type_ = GenericAlias(type_origin, new_arg_types)  # type: ignore
     return type_

--- a/tests/unit/test_field.py
+++ b/tests/unit/test_field.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+from typing import Optional
+
+import odmantic
 import pytest
 
 from odmantic.field import Field
@@ -89,3 +93,19 @@ def test_field_required_in_doc_default_factory_enabled():
         }
 
     assert not M.__odm_fields__["field"].is_required_in_doc()
+
+
+def test_multiple_optional_fields():
+    class M(Model):
+        field: str = Field(default_factory=lambda: "hi")  # pragma: no cover
+        optionalBoolField: Optional[bool] = None
+        optionalDatetimeField: Optional[datetime] = None
+
+    assert M.__odm_fields__["optionalBoolField"].pydantic_field.annotation == Optional[bool]
+    assert M.__odm_fields__["optionalDatetimeField"].pydantic_field.annotation == Optional[odmantic.bson._datetime]
+
+    try:
+        instance = M(field="Hi")
+        instance.optionalBoolField = True
+    except:
+        pytest.fail("a boolean value can not be assigned to a boolean field")


### PR DESCRIPTION
This fixes #407 .

The fix avoids the hack to dynamically generate a Union type instance which will just modify the existing Union[int, str] instance and re-use it for any type annotated with Union.