### PR TITLE
chore(bench): update CodSpeed/action to v2

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -33,7 +33,7 @@ jobs:
           pip install flit
           pip install ".[test]"
       - name: Run benches
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
           run: pytest tests/integration/benchmarks --codspeed
         env:


### PR DESCRIPTION
Upgrading to the v2 of https://github.com/CodSpeedHQ/action will bring a better base run selection algorithm, better logging, and continued support.