### PR TITLE
feat: add `exclude_none` parameter to `model_dump_doc`

### DIFF
--- a/odmantic/model.py
+++ b/odmantic/model.py
@@ -709,11 +709,17 @@ class _BaseODMModel(pydantic.BaseModel, metaclass=ABCMeta):
     @deprecated(
         "doc is deprecated, please use model_dump_doc instead",
     )
-    def doc(self, include: Optional["AbstractSetIntStr"] = None) -> Dict[str, Any]:
-        return self.model_dump_doc(include=include)
+    def doc(
+        self,
+        include: Optional["AbstractSetIntStr"] = None,
+        exclude_none: bool = False,
+    ) -> Dict[str, Any]:
+        return self.model_dump_doc(include=include, exclude_none=exclude_none)
 
     def model_dump_doc(
-        self, include: Optional["AbstractSetIntStr"] = None
+        self,
+        include: Optional["AbstractSetIntStr"] = None,
+        exclude_none: bool = False,
     ) -> Dict[str, Any]:
         """Generate a document (BSON) representation of the instance (as a dictionary).
 
@@ -724,7 +730,7 @@ class _BaseODMModel(pydantic.BaseModel, metaclass=ABCMeta):
         Returns:
             the document associated to the instance
         """
-        raw_doc = self.model_dump()
+        raw_doc = self.model_dump(exclude_none=exclude_none)
         doc = self.__doc(raw_doc, type(self), include)
         return doc
 
@@ -736,6 +742,8 @@ class _BaseODMModel(pydantic.BaseModel, metaclass=ABCMeta):
     ) -> Dict[str, Any]:
         doc: Dict[str, Any] = {}
         for field_name, field in model.__odm_fields__.items():
+            if field_name not in raw_doc:
+                continue
             if include is not None and field_name not in include:
                 continue
             if isinstance(field, ODMReference):


### PR DESCRIPTION
This PR closes #502 issue.

Demo:

```python
In [1]: from odmantic import Field, Model, EmbeddedModel
    ...: from typing import Optional
    ...: 
    ...: class Mother(EmbeddedModel):
    ...:     name: Optional[str] = None
    ...: 
    ...: class Person(Model):
    ...:     name: Optional[str] = None
    ...:     mother: Mother = None
    ...: 

In [2]: p = Person(mother=Mother())

In [3]: p.model_dump_doc()
Out[3]: 
{'name': None,
 'mother': {'name': None},
 '_id': ObjectId('671e9987bab71c701c80d08f')}

In [4]: p.model_dump_doc(exclude_none=True)
Out[4]: {'mother': {}, '_id': ObjectId('671e9987bab71c701c80d08f')}
```