### PR TITLE
Add client metadata

### DIFF
--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -328,8 +328,6 @@ class AIOEngine(BaseEngine):
             )
         if client is None:
             client = AsyncIOMotorClient(driver=_DRIVER_INFO)
-        elif hasattr(client, "append_metadata"):
-            client.append_metadata(_DRIVER_INFO)
         super().__init__(client=client, database=database)
 
     def get_collection(self, model: Type[ModelType]) -> "AsyncIOMotorCollection":
@@ -741,7 +739,7 @@ class SyncEngine(BaseEngine):
         """
         if client is None:
             client = MongoClient(driver=_DRIVER_INFO)
-        elif hasattr(client, "append_metadata"):
+        else:
             client.append_metadata(_DRIVER_INFO)
         super().__init__(client=client, database=database)
 

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -18,12 +18,15 @@ from typing import (
     cast,
 )
 
+from importlib.metadata import version as _get_version
+
 import pymongo
 from pymongo import MongoClient
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
 from pymongo.command_cursor import CommandCursor
 from pymongo.database import Database
+from pymongo.driver_info import DriverInfo
 
 from odmantic.exceptions import DocumentNotFoundError, DuplicateKeyError
 from odmantic.field import FieldProxy, ODMReference
@@ -52,6 +55,8 @@ try:
 except ImportError:  # pragma: no cover
     motor = None
 
+
+_DRIVER_INFO = DriverInfo(name="ODMantic", version=_get_version("odmantic"))
 
 ModelType = TypeVar("ModelType", bound=Model)
 
@@ -322,7 +327,9 @@ class AIOEngine(BaseEngine):
                 + 'pip install "odmantic[motor]"'
             )
         if client is None:
-            client = AsyncIOMotorClient()
+            client = AsyncIOMotorClient(driver=_DRIVER_INFO)
+        else:
+            client.append_metadata(_DRIVER_INFO)
         super().__init__(client=client, database=database)
 
     def get_collection(self, model: Type[ModelType]) -> "AsyncIOMotorCollection":
@@ -733,7 +740,9 @@ class SyncEngine(BaseEngine):
             database: name of the database to use
         """
         if client is None:
-            client = MongoClient()
+            client = MongoClient(driver=_DRIVER_INFO)
+        else:
+            client.append_metadata(_DRIVER_INFO)
         super().__init__(client=client, database=database)
 
     def get_collection(self, model: Type[ModelType]) -> "Collection":

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -1,3 +1,4 @@
+from importlib.metadata import version as _get_version
 from typing import (
     Any,
     AsyncGenerator,
@@ -17,8 +18,6 @@ from typing import (
     Union,
     cast,
 )
-
-from importlib.metadata import version as _get_version
 
 import pymongo
 from pymongo import MongoClient

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -739,7 +739,7 @@ class SyncEngine(BaseEngine):
         """
         if client is None:
             client = MongoClient(driver=_DRIVER_INFO)
-        else:
+        elif hasattr(client, "append_metadata"):
             client.append_metadata(_DRIVER_INFO)
         super().__init__(client=client, database=database)
 

--- a/odmantic/engine.py
+++ b/odmantic/engine.py
@@ -328,7 +328,7 @@ class AIOEngine(BaseEngine):
             )
         if client is None:
             client = AsyncIOMotorClient(driver=_DRIVER_INFO)
-        else:
+        elif hasattr(client, "append_metadata"):
             client.append_metadata(_DRIVER_INFO)
         super().__init__(client=client, database=database)
 
@@ -741,7 +741,7 @@ class SyncEngine(BaseEngine):
         """
         if client is None:
             client = MongoClient(driver=_DRIVER_INFO)
-        else:
+        elif hasattr(client, "append_metadata"):
             client.append_metadata(_DRIVER_INFO)
         super().__init__(client=client, database=database)
 

--- a/tests/integration/test_engine.py
+++ b/tests/integration/test_engine.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
 
 import pytest
 from bson import ObjectId as BsonObjectId
@@ -40,6 +41,12 @@ def test_no_motor_raises_for_aioengine_client_creation():
 def test_default_pymongo_client_creation():
     engine = SyncEngine()
     assert isinstance(engine.client, MongoClient)
+
+
+def test_sync_engine_calls_append_metadata_on_existing_client():
+    client = MagicMock(spec=MongoClient)
+    SyncEngine(client=client)
+    client.append_metadata.assert_called_once()
 
 
 def test_no_motor_passes_with_syncengine_client_creation():

--- a/tests/integration/test_engine.py
+++ b/tests/integration/test_engine.py
@@ -44,7 +44,7 @@ def test_default_pymongo_client_creation():
 
 
 def test_sync_engine_calls_append_metadata_on_existing_client():
-    client = MagicMock(spec=MongoClient)
+    client = MagicMock()
     SyncEngine(client=client)
     client.append_metadata.assert_called_once()
 


### PR DESCRIPTION
Similar to https://github.com/mongodb-labs/flask-pymongo/pull/165, This PR will wrap the `MongoClient` creation with [`pymongo.driver_info.DriverInfo`](https://pymongo.readthedocs.io/en/stable/api/pymongo/driver_info.html#pymongo.driver_info.DriverInfo) which makes it easier to filter `mongod` logs for connections that originate from Flask-PyMongo.

For example:

> {"t":{"$date":"2024-06-03T16:10:26.686-04:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn225","msg":"client metadata","attr":{"remote":"127.0.0.1:61857","client":"conn225","negotiatedCompressors":[],"doc":{"driver":{"name":"PyMongo|ODMantic","version":"3.11.4|0.7.0"},"os":{"type":"Darwin","name":"Darwin","architecture":"x86_64","version":"14.5"},"platform":"CPython 3.10.3.final.0"}}}